### PR TITLE
move pyspark jobs requirements.txt

### DIFF
--- a/jobs/requirements.txt
+++ b/jobs/requirements.txt
@@ -1,3 +1,2 @@
 datasets==3.0.0
 hnswlib==0.8.0
-pyspark~=3.5.0


### PR DESCRIPTION
common ML related modules such as numpy, pandas, pyspark have been included in Dataproc service. We only need to install `datasets`, and `hnswlib`.